### PR TITLE
feat: add `submode.default` for define default mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,13 @@ The following user events will be triggered.
         - `rhs: string | fun():string?` Rhs of keymap. Same as `rhs` of `vim.keymap.set`.
         - `opts?: table` Options of this keymap. Same as `opts` of `vim.keymap.set`.
 
+- `default(name, lhs, rhs, opts)`
+    - Add a default mapping to `name`. Same interface as `vim.keymap.set`.
+    - `name: string` Name of target submode.
+    - `lhs: string` Lhs of mapping.
+    - `rhs: string | fun():string?` Rhs of mapping. Can be function.
+    - `opts?: table` Options of this mapping. Same as `opts` of `vim.keymap.set`.
+
 - `set(name, lhs, rhs, opts)`
     - Add a mapping to `name`. Same interface as `vim.keymap.set`.
     - `name: string` Name of target submode.

--- a/lua/submode/init.lua
+++ b/lua/submode/init.lua
@@ -61,17 +61,8 @@ function M.create(name, info, ...)
         end)
     end
 
-    ---Register mappings.
     for _, map in ipairs { ... } do
-        vim.validate {
-            lhs = { map.lhs, "string" },
-            rhs = { map.rhs, { "string", "function" } },
-            opts = { map.opts, "table", true },
-        }
-        M.state.submode_to_default_mappings[name][map.lhs] = {
-            rhs = map.rhs,
-            opts = map.opts,
-        }
+        M.default(name, map.lhs, map.rhs, map.opts)
     end
 
     if info.leave_when_mode_changed then
@@ -85,7 +76,33 @@ function M.create(name, info, ...)
     end
 end
 
----Add a mapping to `name`. Same interface as `vim.keymap.set`
+---Add a default mapping to `name`. Same interface as `vim.keymap.set`.
+---@param name string Name of target submode.
+---@param lhs string Lhs of mapping.
+---@param rhs string | fun():string? Rhs of mapping. Can be function.
+---@param opts? table Options of this mapping. Same as `opts` of `vim.keymap.set`.
+function M.default(name, lhs, rhs, opts)
+    vim.validate {
+        name = { name, "string" },
+        lhs = { lhs, "string" },
+        rhs = { rhs, { "string", "function" } },
+        opts = { opts, "table", true },
+    }
+
+    if M.state.current_mode ~= "" then
+        vim.notify("`submode.default` must not be called when submode is actived", vim.log.levels.ERROR, {
+            title = "submode.nvim",
+        })
+        return
+    end
+
+    M.state.submode_to_default_mappings[name][lhs] = {
+        rhs = rhs,
+        opts = opts,
+    }
+end
+
+---Add a mapping to `name`. Same interface as `vim.keymap.set`.
 ---@param name string Name of target submode.
 ---@param lhs string Lhs of mapping.
 ---@param rhs string | fun():string? Rhs of mapping. Can be function.


### PR DESCRIPTION
The `submode.create` has ability to define default mappings to the submode, but it makes code longer because it require normally 3 to 5 line for each definition.
So, this commit introduce a new api `submode.default`. This api is compatible with `vim.keymap.set`, as `submode.create` accept similar value for each maping.
With this api, user can define default mapping as little as 1 to 3 lines for each mapping.

Closes #17 